### PR TITLE
Update service worker fallback

### DIFF
--- a/@types/global-env.d.ts
+++ b/@types/global-env.d.ts
@@ -5,4 +5,10 @@ interface Env {
 
 declare module globalThis {
   var env: Env;
+  var queryFetch:
+    | undefined
+    | ((
+        input: string | URL | globalThis.Request,
+        init?: RequestInit
+      ) => Promise<Response>);
 }

--- a/libs/data-access/admin-api/src/lib/api/client.ts
+++ b/libs/data-access/admin-api/src/lib/api/client.ts
@@ -8,7 +8,8 @@ import createClient from 'openapi-fetch';
 
 const client = createClient<paths>({
   fetch: (...args) => {
-    return globalThis.fetch(...args);
+    const fetcher = globalThis.queryFetch ?? globalThis.fetch;
+    return fetcher(...args);
   },
 });
 const errorMiddleware: Middleware = {

--- a/libs/data-access/admin-api/src/lib/api/client.ts
+++ b/libs/data-access/admin-api/src/lib/api/client.ts
@@ -31,7 +31,9 @@ const errorMiddleware: Middleware = {
       if (typeof body === 'object') {
         throw new RestateError(body.message, body.restate_code ?? '');
       }
-      throw new Error(body);
+      throw new Error(
+        body || 'An unexpected error occurred. Please try again later.'
+      );
     }
     if (response.ok && request.url.endsWith('health')) {
       return new Response(JSON.stringify({}), {

--- a/libs/data-access/middleware-service-worker/src/lib/register.ts
+++ b/libs/data-access/middleware-service-worker/src/lib/register.ts
@@ -21,9 +21,12 @@ export async function register() {
       });
 
       await navigator.serviceWorker.ready;
+      return;
     } catch (error) {
-      console.error(`Registration failed with ${error}`);
-      globalThis.fetch = queryFetcher;
+      console.warn(`Registration failed with ${error}`);
     }
+  } else {
+    console.warn('Service Worker not available');
   }
+  globalThis.queryFetch = queryFetcher;
 }

--- a/libs/data-access/middleware-service-worker/tsconfig.lib.json
+++ b/libs/data-access/middleware-service-worker/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/explainers/tsconfig.lib.json
+++ b/libs/features/explainers/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/health/tsconfig.lib.json
+++ b/libs/features/health/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/invocation-route/tsconfig.lib.json
+++ b/libs/features/invocation-route/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/invocations-route/tsconfig.lib.json
+++ b/libs/features/invocations-route/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/overview-route/tsconfig.lib.json
+++ b/libs/features/overview-route/tsconfig.lib.json
@@ -6,7 +6,8 @@
       "node",
 
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/restate-context/tsconfig.lib.json
+++ b/libs/features/restate-context/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/libs/features/version/tsconfig.lib.json
+++ b/libs/features/version/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "@nx/react/typings/image.d.ts",
+      "../../../@types/global-env.d.ts"
     ]
   },
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -136,5 +136,5 @@
       }
     }
   },
-  "packageManager": "pnpm@9.15.0"
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
Makes sure if for any reason the service worker has not been installed, we fallback to using the patched `queryFetch`