### PR TITLE
Update Lambda and IAM role ARN validation rules

### DIFF
--- a/libs/features/overview-route/src/lib/RegisterDeployment/AssumeARNRole.tsx
+++ b/libs/features/overview-route/src/lib/RegisterDeployment/AssumeARNRole.tsx
@@ -1,5 +1,6 @@
 import { FormFieldInput } from '@restate/ui/form-field';
 import { useRegisterDeploymentContext } from './Context';
+import { InlineTooltip } from '@restate/ui/tooltip';
 
 export function AssumeARNRole() {
   const { updateAssumeRoleArn, assumeRoleArn } = useRegisterDeploymentContext();
@@ -7,15 +8,27 @@ export function AssumeARNRole() {
   return (
     <FormFieldInput
       name="assume_role_arn"
-      placeholder="arn:aws:sts::{acc}:assumed-role/{role}/{func}"
-      pattern="^arn:aws:sts::(\d{12}):assumed-role\/([^\/]+)\/([^\/]+)$"
+      placeholder="arn:aws:iam::{account}:role/{role-name}"
+      pattern="^arn:aws:iam::\d{12}:role(\/[\w-]+)*\/[\w+-]+$"
       value={assumeRoleArn}
       onChange={updateAssumeRoleArn}
       label={
         <>
-          <span slot="title">Assume role ARN</span>
+          <span slot="title">
+            <InlineTooltip
+              title="Assumed role"
+              description={
+                <p>
+                  This role must exist in your account, it must trust Restate Cloud to assume it,
+                  and it must have permission to invoke the Lambda function containing the handler.
+                </p>
+              }
+              learnMoreHref="https://docs.restate.dev/deploy/server/cloud#aws-lambda-services">
+                Role ARN
+            </InlineTooltip>
+          </span>
           <span slot="description" className="leading-5 text-code block">
-            ARN of a role to use when invoking the Lambda
+            AWS role ARN that Restate Cloud can assume to invoke the Lambda function
           </span>
         </>
       }

--- a/libs/features/overview-route/src/lib/RegisterDeployment/AssumeARNRole.tsx
+++ b/libs/features/overview-route/src/lib/RegisterDeployment/AssumeARNRole.tsx
@@ -19,16 +19,19 @@ export function AssumeARNRole() {
               title="Assumed role"
               description={
                 <p>
-                  This role must exist in your account, it must trust Restate Cloud to assume it,
-                  and it must have permission to invoke the Lambda function containing the handler.
+                  This role must exist in your account, it must trust Restate
+                  Cloud to assume it, and it must have permission to invoke the
+                  Lambda function containing the handler.
                 </p>
               }
-              learnMoreHref="https://docs.restate.dev/deploy/server/cloud#aws-lambda-services">
-                Role ARN
+              learnMoreHref="https://docs.restate.dev/deploy/server/cloud#aws-lambda-services"
+            >
+              Role ARN
             </InlineTooltip>
           </span>
           <span slot="description" className="leading-5 text-code block">
-            AWS role ARN that Restate Cloud can assume to invoke the Lambda function
+            AWS role ARN that Restate Cloud can assume to invoke the Lambda
+            function
           </span>
         </>
       }

--- a/libs/features/overview-route/src/lib/RegisterDeployment/Form.tsx
+++ b/libs/features/overview-route/src/lib/RegisterDeployment/Form.tsx
@@ -95,7 +95,7 @@ export function RegistrationForm() {
               </ServiceDeploymentExplainer>
             </>
           }
-          description="Please provide the HTTP endpoint or Lambda ARN where your service is running:"
+          description="Please provide the HTTP endpoint or Lambda function version ARN where your service is running:"
         >
           <EndpointForm />
         </Container>
@@ -138,13 +138,13 @@ function EndpointForm() {
         type={isLambda ? 'text' : 'url'}
         {...(isLambda && {
           pattern:
-            '^arn:aws:lambda:[a-z0-9\\-]+:\\d+:function:[a-zA-Z0-9\\-_]+:\\d+$',
+            '^arn:aws:lambda:[a-z0-9\\-]+:\\d+:function:[a-zA-Z0-9\\-_]+:.+$',
         })}
         name="endpoint"
         className="[&_.error]:absolute [&_.error]:pt-1 [&_input:not([type=radio])]:absolute left-0 right-0 my-2 [&_input:not([type=radio])]:pr-[4.75rem]"
         placeholder={
           isLambda
-            ? 'arn:aws:lambda:{reg}:{acc}:function:{func}:{version}'
+            ? 'arn:aws:lambda:{region}:{account}:function:{function-name}:{version}'
             : 'http://localhost:9080'
         }
         label={isLambda ? 'Lambda ARN' : 'HTTP endpoint'}


### PR DESCRIPTION
Loosen the validation rules around versions slightly to allow for aliases like $LATEST to be used.

Update the STS session id pattern with an IAM role ARN pattern. Add link to role trust setup documentation.

---

This permits role ARNs like `arn:aws:iam::663487780041:role/LambdaTsCdkStack-nik-InvokerRole4DB2757E-QFh1yjd4kBYT` - the previous pattern matches STS session ids which are what you might see `GetCallerIdentity` return, but they are not a valid ARN that Restate Cloud can assume. 

I've also loosened up the validation pattern for function ARNs so that we can accept built-in and customer aliases like `arn:aws:lambda:eu-central-1:663487780041:function:my-greeter-v1:$LATEST`.

Also, I feel strongly that the role ARN should be displayed immediately once the user selects Lambda deployment - in practice, this will be used ~100% of the time in Restate Cloud. Not setting one will only ever work if the Lambda is public-access, which is almost certainly a misconfiguration. I tried to make it work but could not get the layout right at all :-)