### PR TITLE
Replace humantime references with jiff's friendly format

### DIFF
--- a/libs/features/overview-route/src/lib/Details/Service.tsx
+++ b/libs/features/overview-route/src/lib/Details/Service.tsx
@@ -261,11 +261,11 @@ function ServiceForm({
             <span className="text-gray-500 px-4 pb-2 block text-xs normal-case font-normal mt-2">
               Configured using the{' '}
               <Link
-                href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                humantime
+                jiff friendly
               </Link>{' '}
               format.
             </span>
@@ -297,11 +297,11 @@ function ServiceForm({
                   Choose from the example options above, or enter a custom value
                   in the{' '}
                   <Link
-                    href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                    href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    humantime
+                    jiff friendly
                   </Link>{' '}
                   format.
                 </>
@@ -342,11 +342,11 @@ function ServiceForm({
                     Choose from the example options above, or enter a custom
                     value in the{' '}
                     <Link
-                      href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                      href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      humantime
+                      jiff friendly
                     </Link>{' '}
                     format.
                   </>
@@ -370,11 +370,11 @@ function ServiceForm({
             <span className="text-gray-500 px-4 pb-2 block text-xs normal-case font-normal mt-2">
               Configured using the{' '}
               <Link
-                href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                humantime
+                jiff friendly
               </Link>{' '}
               format.
             </span>
@@ -407,11 +407,11 @@ function ServiceForm({
                   Choose from the example options above, or enter a custom value
                   in the{' '}
                   <Link
-                    href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                    href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    humantime
+                    jiff friendly
                   </Link>{' '}
                   format.
                 </>
@@ -451,11 +451,11 @@ function ServiceForm({
                   Choose from the example options above, or enter a custom value
                   in the{' '}
                   <Link
-                    href="https://docs.rs/humantime/latest/humantime/fn.parse_duration.html#examples"
+                    href="https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    humantime
+                    jiff friendly
                   </Link>{' '}
                   format.
                 </>

--- a/libs/util/humantime/src/lib/humantime.ts
+++ b/libs/util/humantime/src/lib/humantime.ts
@@ -9,7 +9,7 @@ interface Duration {
 }
 
 const HUMANTIME_REGEXP =
-  /(?<unitValue>\d+)\s*(?<unit>msec|ms|seconds|second|sec|minute|minutes|hours|hour|days|day|months|month|years|year|y|min|M|m|s|h|d)/gm;
+  /(?<unitValue>\d+)\s*(?<unit>msec|ms|seconds|second|sec|minute|minutes|hours|hour|days|day|min|M|m|s|h|d)/gm;
 
 const HUMANTIME_UNITS_VALUES = [
   'msec',
@@ -28,12 +28,6 @@ const HUMANTIME_UNITS_VALUES = [
   'days',
   'day',
   'd',
-  'months',
-  'month',
-  'M',
-  'years',
-  'year',
-  'y',
 ] as const;
 
 export const HUMANTIME_PATTERN_INPUT = HUMANTIME_UNITS_VALUES.map(
@@ -60,12 +54,6 @@ const UNIT_MAPS: Record<
   days: 'days',
   day: 'days',
   d: 'days',
-  months: 'months',
-  month: 'months',
-  M: 'months',
-  years: 'years',
-  year: 'years',
-  y: 'years',
 };
 
 export function formatHumantime(value?: string | null) {


### PR DESCRIPTION
This change remove the duration units of months and years, as we will no longer support those in Restate > 1.3.2.

Keeping up with https://github.com/restatedev/restate/pull/2917.

---

I'm not too sure if this is all there is to it; the `humantime` module mentions running tests but I didn't see any :-)