### PR TITLE
Add wide mode toggle for invocation detail page

### DIFF
--- a/libs/features/invocation-route/src/lib/JournalV2.tsx
+++ b/libs/features/invocation-route/src/lib/JournalV2.tsx
@@ -51,6 +51,8 @@ export function JournalV2({
   withTimeline = true,
   isLive = false,
   setIsLive,
+  isWideMode = false,
+  setIsWideMode,
 }: {
   invocationId: string;
   className?: string;
@@ -59,6 +61,8 @@ export function JournalV2({
   withTimeline?: boolean;
   isLive?: boolean;
   setIsLive?: (value: boolean) => void;
+  isWideMode?: boolean;
+  setIsWideMode?: (value: boolean) => void;
 }) {
   const [invocationIds, setInvocationIds] = useState([String(invocationId)]);
 
@@ -275,6 +279,19 @@ export function JournalV2({
                     <Icon name={IconName.ScanSearch} className="h-4 w-4" />
                   </Link>
                 </HoverTooltip>
+                {setIsWideMode && (
+                  <HoverTooltip content={isWideMode ? 'Normal mode' : 'Wide mode'}>
+                    <Button
+                      variant="icon"
+                      onClick={() => setIsWideMode(!isWideMode)}
+                    >
+                      <Icon
+                        name={isWideMode ? IconName.Minimize : IconName.Maximize}
+                        className="h-4 w-4"
+                      />
+                    </Button>
+                  </HoverTooltip>
+                )}
               </div>
             </div>
             <div className="relative font-mono text-0.5xs">

--- a/libs/features/invocation-route/src/lib/invocation.route.tsx
+++ b/libs/features/invocation-route/src/lib/invocation.route.tsx
@@ -17,6 +17,8 @@ import { WorkflowKeySection } from './WorkflowKeySection';
 import { tv } from '@restate/util/styles';
 import { Copy } from '@restate/ui/copy';
 import { LIVE_JOURNAL } from './constants';
+import { getUserPreference, setUserPreference } from '@restate/features/user-preference';
+import { useState } from 'react';
 
 const metadataContainerStyles = tv({
   base: 'mt-6 hidden grid-cols-1 gap-2 gap-y-4 rounded-xl md:grid-cols-2 [&:has(*)]:grid',
@@ -42,6 +44,14 @@ const lastFailureContainer = tv({
 function Component() {
   const { id } = useParams<{ id: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [isWideMode, setIsWideModeState] = useState(() =>
+    getUserPreference('invocation-wide-mode'),
+  );
+
+  const setIsWideMode = (value: boolean) => {
+    setIsWideModeState(value);
+    setUserPreference('invocation-wide-mode', value);
+  };
 
   const {
     data: journalAndInvocationData,
@@ -80,7 +90,19 @@ function Component() {
 
   return (
     <InvocationPageProvider isInInvocationPage>
-      <div className="flex flex-col">
+      <div
+        className="flex flex-col"
+        style={
+          isWideMode
+            ? {
+                width: '95vw',
+                position: 'relative',
+                left: '50%',
+                transform: 'translateX(-50%)',
+              }
+            : undefined
+        }
+      >
         <div className="@container flex flex-col gap-1">
           <Link
             className="flex items-center gap-1 text-sm text-gray-500"
@@ -198,6 +220,8 @@ function Component() {
                   return old;
                 });
               }}
+              isWideMode={isWideMode}
+              setIsWideMode={setIsWideMode}
             />
           </div>
         </div>

--- a/libs/features/user-preference/src/lib/userPreference.tsx
+++ b/libs/features/user-preference/src/lib/userPreference.tsx
@@ -5,7 +5,8 @@ export type UserPreferenceId =
   | 'skip-kill-action-dialog'
   | 'skip-purge-action-dialog'
   | 'skip-pause-action-dialog'
-  | 'skip-retry-action-dialog';
+  | 'skip-retry-action-dialog'
+  | 'invocation-wide-mode';
 
 export function getUserPreference(id: UserPreferenceId) {
   if (typeof localStorage === 'undefined') return false;


### PR DESCRIPTION
## Summary

Adds a new wide mode feature to the invocation detail page that allows users to expand the view to 95% of viewport width for better visibility of journal activations.

**Key Features:**
- Toggle button with maximize/minimize icons in the journal toolbar
- Expands page width from default max-w-6xl (~1152px) to 95vw
- Preference persisted to localStorage across sessions
- Scoped only to invocation detail page

**Changes:**
- Add `invocation-wide-mode` user preference type
- Add wide mode toggle button in JournalV2 toolbar next to Introspect button
- Implement viewport-width expansion using CSS positioning technique
- State management with localStorage persistence

## Test plan

- [x] Navigate to an invocation detail page
- [x] Verify the maximize icon appears in the journal toolbar
- [x] Click the maximize icon and verify the page expands to fill most of the viewport
- [x] Verify the icon changes to minimize
- [x] Click minimize and verify the page returns to normal width
- [x] Refresh the page and verify the wide mode preference is preserved
- [x] Test on different viewport sizes to ensure responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)